### PR TITLE
Fix bug leading to wrong token creator when parameter.address != send…

### DIFF
--- a/src/hicdex/handlers/on_mint.py
+++ b/src/hicdex/handlers/on_mint.py
@@ -12,6 +12,7 @@ async def on_mint(
     mint: TransactionContext[MintParameter, HenObjktsStorage],
 ) -> None:
     holder, _ = await models.Holder.get_or_create(address=mint.parameter.address)
+    creator, _ = await models.Holder.get_or_create(address=mint.data.sender_address)
     if await models.Token.exists(id=mint.parameter.token_id):
         return
 
@@ -24,7 +25,7 @@ async def on_mint(
         display_uri='',
         thumbnail_uri='',
         mime='',
-        creator=holder,
+        creator=creator,
         supply=mint.parameter.amount,
         level=mint.data.level,
         timestamp=mint.data.timestamp,


### PR DESCRIPTION
I stumbled upon this bug while testing https://www.muralis.xyz. We issue tokens directly through the smart contract, and the address parameter is different than the sender (the smart contract), so the initial holder is **not** the creator. This leads to the token not showing up on hicetnunc.

Hopefully, this small change fixes the issue.