### PR TITLE
add conclusion timestamps & fix extension time

### DIFF
--- a/src/hicdex/handlers/on_bid_english.py
+++ b/src/hicdex/handlers/on_bid_english.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 import hicdex.models as models
 from dipdup.context import HandlerContext
 from dipdup.models import Transaction
@@ -20,3 +22,9 @@ async def on_bid_english(
         level=bid.data.level,
     )
     await bid_object.save()
+
+    # increase end_time of auction if the bid came in during last `extension_time` seconds
+    if auction.end_time - bid_object.timestamp < timedelta(seconds=auction.extension_time):
+        auction.end_time = bid_object.timestamp + timedelta(seconds=auction.extension_time)
+        await auction.save()
+

--- a/src/hicdex/handlers/on_buy_dutch.py
+++ b/src/hicdex/handlers/on_buy_dutch.py
@@ -18,7 +18,7 @@ async def on_buy_dutch(
 
     auction_model.status = models.AuctionStatus.CONCLUDED
 
-    auction_model.conclusion_level = buy.data.level
-    auction_model.conclusion_timestamp = buy.data.timestamp
+    auction_model.update_level = buy.data.level
+    auction_model.update_timestamp = buy.data.timestamp
 
     await auction_model.save()

--- a/src/hicdex/handlers/on_buy_dutch.py
+++ b/src/hicdex/handlers/on_buy_dutch.py
@@ -17,4 +17,8 @@ async def on_buy_dutch(
     auction_model.buy_price = buy.data.amount  # type: ignore
 
     auction_model.status = models.AuctionStatus.CONCLUDED
+
+    auction_model.conclusion_level = buy.data.level
+    auction_model.conclusion_timestamp = buy.data.timestamp
+
     await auction_model.save()

--- a/src/hicdex/handlers/on_cancel_dutch.py
+++ b/src/hicdex/handlers/on_cancel_dutch.py
@@ -12,7 +12,7 @@ async def on_cancel_dutch(
     auction_model = await models.DutchAuction.filter(id=int(cancel_auction.parameter.__root__)).get()
     auction_model.status = models.AuctionStatus.CANCELLED
 
-    auction_model.conclusion_level = cancel_auction.data.level
-    auction_model.conclusion_timestamp = cancel_auction.data.timestamp
+    auction_model.update_level = cancel_auction.data.level
+    auction_model.update_timestamp = cancel_auction.data.timestamp
 
     await auction_model.save()

--- a/src/hicdex/handlers/on_cancel_dutch.py
+++ b/src/hicdex/handlers/on_cancel_dutch.py
@@ -11,4 +11,8 @@ async def on_cancel_dutch(
 ) -> None:
     auction_model = await models.DutchAuction.filter(id=int(cancel_auction.parameter.__root__)).get()
     auction_model.status = models.AuctionStatus.CANCELLED
+
+    auction_model.conclusion_level = cancel_auction.data.level
+    auction_model.conclusion_timestamp = cancel_auction.data.timestamp
+
     await auction_model.save()

--- a/src/hicdex/handlers/on_cancel_english.py
+++ b/src/hicdex/handlers/on_cancel_english.py
@@ -12,7 +12,7 @@ async def on_cancel_english(
     auction_model = await models.EnglishAuction.filter(id=int(cancel_auction.parameter.__root__)).get()
     auction_model.status = models.AuctionStatus.CANCELLED
 
-    auction_model.conclusion_level = cancel_auction.data.level
-    auction_model.conclusion_timestamp = cancel_auction.data.timestamp
+    auction_model.update_level = cancel_auction.data.level
+    auction_model.update_timestamp = cancel_auction.data.timestamp
 
     await auction_model.save()

--- a/src/hicdex/handlers/on_cancel_english.py
+++ b/src/hicdex/handlers/on_cancel_english.py
@@ -11,4 +11,8 @@ async def on_cancel_english(
 ) -> None:
     auction_model = await models.EnglishAuction.filter(id=int(cancel_auction.parameter.__root__)).get()
     auction_model.status = models.AuctionStatus.CANCELLED
+
+    auction_model.conclusion_level = cancel_auction.data.level
+    auction_model.conclusion_timestamp = cancel_auction.data.timestamp
+
     await auction_model.save()

--- a/src/hicdex/handlers/on_conclude_english.py
+++ b/src/hicdex/handlers/on_conclude_english.py
@@ -12,7 +12,7 @@ async def on_conclude_english(
     auction_model = await models.EnglishAuction.filter(id=int(conclude_auction.parameter.__root__)).get()
     auction_model.status = models.AuctionStatus.CONCLUDED
 
-    auction_model.conclusion_level = conclude_auction.data.level
-    auction_model.conclusion_timestamp = conclude_auction.data.timestamp
+    auction_model.update_level = conclude_auction.data.level
+    auction_model.update_timestamp = conclude_auction.data.timestamp
 
     await auction_model.save()

--- a/src/hicdex/handlers/on_conclude_english.py
+++ b/src/hicdex/handlers/on_conclude_english.py
@@ -11,4 +11,8 @@ async def on_conclude_english(
 ) -> None:
     auction_model = await models.EnglishAuction.filter(id=int(conclude_auction.parameter.__root__)).get()
     auction_model.status = models.AuctionStatus.CONCLUDED
+
+    auction_model.conclusion_level = conclude_auction.data.level
+    auction_model.conclusion_timestamp = conclude_auction.data.timestamp
+
     await auction_model.save()

--- a/src/hicdex/handlers/on_fulfill_ask.py
+++ b/src/hicdex/handlers/on_fulfill_ask.py
@@ -27,4 +27,6 @@ async def on_fulfill_ask(
     ask.amount_left -= 1  # type: ignore
     if ask.amount_left == 0:
         ask.status = models.AuctionStatus.CONCLUDED
+        ask.conclusion_level = fulfill_ask.data.level
+        ask.conclusion_timestamp = fulfill_ask.data.timestamp
     await ask.save()

--- a/src/hicdex/handlers/on_fulfill_ask.py
+++ b/src/hicdex/handlers/on_fulfill_ask.py
@@ -27,6 +27,6 @@ async def on_fulfill_ask(
     ask.amount_left -= 1  # type: ignore
     if ask.amount_left == 0:
         ask.status = models.AuctionStatus.CONCLUDED
-        ask.conclusion_level = fulfill_ask.data.level
-        ask.conclusion_timestamp = fulfill_ask.data.timestamp
+        ask.update_level = fulfill_ask.data.level
+        ask.update_timestamp = fulfill_ask.data.timestamp
     await ask.save()

--- a/src/hicdex/handlers/on_fulfill_bid.py
+++ b/src/hicdex/handlers/on_fulfill_bid.py
@@ -15,7 +15,7 @@ async def on_fulfill_bid(
     bid.seller = seller
     bid.status = models.AuctionStatus.CONCLUDED
 
-    bid.conclusion_level = fulfill_bid.data.level
-    bid.conclusion_timestamp = fulfill_bid.data.timestamp
+    bid.update_level = fulfill_bid.data.level
+    bid.update_timestamp = fulfill_bid.data.timestamp
 
     await bid.save()

--- a/src/hicdex/handlers/on_fulfill_bid.py
+++ b/src/hicdex/handlers/on_fulfill_bid.py
@@ -14,4 +14,8 @@ async def on_fulfill_bid(
 
     bid.seller = seller
     bid.status = models.AuctionStatus.CONCLUDED
+
+    bid.conclusion_level = fulfill_bid.data.level
+    bid.conclusion_timestamp = fulfill_bid.data.timestamp
+
     await bid.save()

--- a/src/hicdex/handlers/on_retract_ask.py
+++ b/src/hicdex/handlers/on_retract_ask.py
@@ -12,7 +12,7 @@ async def on_retract_ask(
     ask = await models.Ask.filter(id=int(retract_ask.parameter.__root__)).get()
     ask.status = models.AuctionStatus.CANCELLED
 
-    ask.conclusion_level = retract_ask.data.level
-    ask.conclusion_timestamp = retract_ask.data.timestamp
+    ask.update_level = retract_ask.data.level
+    ask.update_timestamp = retract_ask.data.timestamp
 
     await ask.save()

--- a/src/hicdex/handlers/on_retract_ask.py
+++ b/src/hicdex/handlers/on_retract_ask.py
@@ -11,4 +11,8 @@ async def on_retract_ask(
 ) -> None:
     ask = await models.Ask.filter(id=int(retract_ask.parameter.__root__)).get()
     ask.status = models.AuctionStatus.CANCELLED
+
+    ask.conclusion_level = retract_ask.data.level
+    ask.conclusion_timestamp = retract_ask.data.timestamp
+
     await ask.save()

--- a/src/hicdex/handlers/on_retract_bid.py
+++ b/src/hicdex/handlers/on_retract_bid.py
@@ -11,4 +11,8 @@ async def on_retract_bid(
 ) -> None:
     bid = await models.Bid.filter(id=int(retract_bid.parameter.__root__)).get()
     bid.status = models.AuctionStatus.CANCELLED
+
+    bid.conclusion_level = retract_bid.data.level
+    bid.conclusion_timestamp = retract_bid.data.timestamp
+
     await bid.save()

--- a/src/hicdex/handlers/on_retract_bid.py
+++ b/src/hicdex/handlers/on_retract_bid.py
@@ -12,7 +12,7 @@ async def on_retract_bid(
     bid = await models.Bid.filter(id=int(retract_bid.parameter.__root__)).get()
     bid.status = models.AuctionStatus.CANCELLED
 
-    bid.conclusion_level = retract_bid.data.level
-    bid.conclusion_timestamp = retract_bid.data.timestamp
+    bid.update_level = retract_bid.data.level
+    bid.update_timestamp = retract_bid.data.timestamp
 
     await bid.save()

--- a/src/hicdex/models.py
+++ b/src/hicdex/models.py
@@ -137,12 +137,15 @@ class EnglishAuction(Model):
     royalties = fields.BigIntField()
     start_time = fields.DatetimeField()
     end_time = fields.DatetimeField()
-    extension_time = fields.BigIntField
+    extension_time = fields.BigIntField()
     price_increment = fields.BigIntField()
     reserve = fields.BigIntField()
 
     level = fields.BigIntField()
     timestamp = fields.DatetimeField()
+
+    conclusion_level = fields.BigIntField(null=True)
+    conclusion_timestamp = fields.DatetimeField(null=True)
 
     class Meta:
         table = 'english_auction'
@@ -179,6 +182,9 @@ class DutchAuction(Model):
     level = fields.BigIntField()
     timestamp = fields.DatetimeField()
 
+    conclusion_level = fields.BigIntField(null=True)
+    conclusion_timestamp = fields.DatetimeField(null=True)
+
     class Meta:
         table = 'dutch_auction'
 
@@ -197,6 +203,9 @@ class Bid(Model):
     level = fields.BigIntField()
     timestamp = fields.DatetimeField()
 
+    conclusion_level = fields.BigIntField(null=True)
+    conclusion_timestamp = fields.DatetimeField(null=True)
+
 
 class Ask(Model):
     id = fields.BigIntField(pk=True)
@@ -212,6 +221,9 @@ class Ask(Model):
 
     level = fields.BigIntField()
     timestamp = fields.DatetimeField()
+
+    conclusion_level = fields.BigIntField(null=True)
+    conclusion_timestamp = fields.DatetimeField(null=True)
 
 
 class FulfilledAsk(Model):

--- a/src/hicdex/models.py
+++ b/src/hicdex/models.py
@@ -144,8 +144,8 @@ class EnglishAuction(Model):
     level = fields.BigIntField()
     timestamp = fields.DatetimeField()
 
-    conclusion_level = fields.BigIntField(null=True)
-    conclusion_timestamp = fields.DatetimeField(null=True)
+    update_level = fields.BigIntField(null=True)
+    update_timestamp = fields.DatetimeField(null=True)
 
     class Meta:
         table = 'english_auction'
@@ -182,8 +182,8 @@ class DutchAuction(Model):
     level = fields.BigIntField()
     timestamp = fields.DatetimeField()
 
-    conclusion_level = fields.BigIntField(null=True)
-    conclusion_timestamp = fields.DatetimeField(null=True)
+    update_level = fields.BigIntField(null=True)
+    update_timestamp = fields.DatetimeField(null=True)
 
     class Meta:
         table = 'dutch_auction'
@@ -203,8 +203,8 @@ class Bid(Model):
     level = fields.BigIntField()
     timestamp = fields.DatetimeField()
 
-    conclusion_level = fields.BigIntField(null=True)
-    conclusion_timestamp = fields.DatetimeField(null=True)
+    update_level = fields.BigIntField(null=True)
+    update_timestamp = fields.DatetimeField(null=True)
 
 
 class Ask(Model):
@@ -222,8 +222,8 @@ class Ask(Model):
     level = fields.BigIntField()
     timestamp = fields.DatetimeField()
 
-    conclusion_level = fields.BigIntField(null=True)
-    conclusion_timestamp = fields.DatetimeField(null=True)
+    update_level = fields.BigIntField(null=True)
+    update_timestamp = fields.DatetimeField(null=True)
 
 
 class FulfilledAsk(Model):


### PR DESCRIPTION
- Adds `conclusion_timestamp` and `conclusion_level` to all objkt.bid models.
- Fixes extension time on English auctions

Maybe `conclusion` is not the best prefix, since I'm using it for cancellation and retraction aswell. Suggestions? @vhf